### PR TITLE
Account creation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}

--- a/app/model/Profile.js
+++ b/app/model/Profile.js
@@ -1,14 +1,54 @@
-var express = require('express');
-var router  = express.Router();
-var DB      = require('../db');
-var _       = require('lodash');
+const express   = require('express');
+const router    = express.Router();
+const DB        = require('../db');
+const _         = require('lodash');
+const moment    = require('moment');
+const sqlstring = require('sqlstring');
+
 /**
  * POST: { userID: string } profile/getAllTrips
  * POST: { userID: string } profile/getAllBookmarks
  * POST: { userID: string } profile/getAllFavorites
  */
+const STATUS_OPTIONS = {
+    ACTIVE:  'ACTIVE',
+    DELETED: 'DELETED' // When user deletes profile
+};
+const ROLE_OPTIONS   = {
+    USER:  'user',
+    ADMIN: 'admin'
+};
 
-// TODO: Code here
+/**
+ * Add a new profile to
+ */
+router.post('/create', async (req, res) => {
+    const {firstName, lastName, userEmail, uid, userImageURL} = req.body;
+    if (!firstName || !lastName || !userEmail || !uid) {
+        return res.status(500).json({
+                                        error: `First name, last name, email, or uid is missing`,
+                                    });
+    } else {
+        try {
+            const dateCreated = sqlstring.escape(new Date().toISOString().slice(0, 19).replace('T', ' ')),
+                  role        = sqlstring.escape(ROLE_OPTIONS.USER),
+                  status      = sqlstring.escape(STATUS_OPTIONS.ACTIVE),
+                  fName       = sqlstring.escape(firstName),
+                  lName       = sqlstring.escape(lastName),
+                  email       = sqlstring.escape(userEmail),
+                  imageURL    = sqlstring.escape(userImageURL),
+                  userID      = sqlstring.escape(uid);
 
+            const query = `INSERT INTO Profile (fName, lName, email, role, userID, dateCreated, userStatus, imageURL) 
+        VALUES (${fName}, ${lName}, ${email}, ${role}, ${userID}, ${dateCreated}, ${status}, ${imageURL})`;
+            console.log('query is', query);
+            const result = await DB.runQuery(query);
+            res.json({success: true});
+        } catch (e) {
+            console.log('Error adding a new profile to the database:', e);
+            res.json({success: false});
+        }
+    }
+});
 
 module.exports = router;

--- a/fire.js
+++ b/fire.js
@@ -1,0 +1,17 @@
+import firebase from 'firebase';
+
+// Initialize Firebase
+const config = {
+    apiKey: process.env.REACT_APP_apiKey,
+    authDomain: process.env.REACT_APP_authDomain,
+    databaseURL: process.env.REACT_APP_databaseURL,
+    projectId: process.env.REACT_APP_projectId,
+    storageBucket: process.env.REACT_APP_storageBucket,
+    messagingSenderId: process.env.messagingSenderId,
+};
+
+const fire = !firebase.apps.length
+    ? firebase.initializeApp(config)
+    : firebase.app();
+
+export default fire;

--- a/package.json
+++ b/package.json
@@ -14,18 +14,22 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@material-ui/core": "^3.5.1",
+    "@material-ui/core": "^3.9.2",
+    "@material-ui/icons": "^3.0.2",
     "async": "^2.6.1",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
+    "classnames": "^2.2.6",
     "dotenv-webpack": "^1.5.7",
     "express": "^4.16.4",
+    "firebase": "^5.8.2",
     "lodash": "^4.17.11",
-    "moment": "^2.22.2",
+    "moment": "^2.24.0",
     "mysql": "^2.16.0",
     "next": "^7.0.2",
     "react": "16.7.0-alpha.2",
-    "react-dom": "16.7.0-alpha.2"
+    "react-dom": "16.7.0-alpha.2",
+    "sqlstring": "^2.3.1"
   },
   "devDependencies": {
     "nodemon": "^1.18.9"

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "dotenv-webpack": "^1.5.7",
     "express": "^4.16.4",
     "firebase": "^5.8.2",
+    "jss": "^9.8.7",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "mysql": "^2.16.0",
     "next": "^7.0.2",
     "react": "16.7.0-alpha.2",
     "react-dom": "16.7.0-alpha.2",
+    "react-jss": "^8.6.1",
     "sqlstring": "^2.3.1"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import App, {Container} from 'next/app';
+import Head from 'next/head';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import JssProvider from 'react-jss/lib/JssProvider';
+import getPageContext from '../src/getPageContext';
+
+class MyApp extends App {
+    constructor() {
+        super();
+        this.pageContext = getPageContext();
+    }
+
+    componentDidMount() {
+        // Remove the server-side injected CSS.
+        const jssStyles = document.querySelector('#jss-server-side');
+        if (jssStyles && jssStyles.parentNode) {
+            jssStyles.parentNode.removeChild(jssStyles);
+        }
+    }
+
+    render() {
+        const {Component, pageProps} = this.props;
+        return (
+            <Container>
+                <Head>
+                    <title>My page</title>
+                </Head>
+                {/* Wrap every page in Jss and Theme providers */}
+                <JssProvider
+                    registry={this.pageContext.sheetsRegistry}
+                    generateClassName={this.pageContext.generateClassName}
+                >
+                    {/* MuiThemeProvider makes the theme available down the React
+              tree thanks to React context. */}
+                    <MuiThemeProvider
+                        theme={this.pageContext.theme}
+                        sheetsManager={this.pageContext.sheetsManager}
+                    >
+                        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+                        <CssBaseline/>
+                        {/* Pass pageContext to the _document though the renderPage enhancer
+                to render collected styles on server-side. */}
+                        <Component pageContext={this.pageContext} {...pageProps} />
+                    </MuiThemeProvider>
+                </JssProvider>
+            </Container>
+        );
+    }
+}
+
+export default MyApp;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Document, {Head, Main, NextScript} from 'next/document';
+import flush from 'styled-jsx/server';
+
+class MyDocument extends Document {
+    render() {
+        const {pageContext} = this.props;
+
+        return (
+            <html lang="en" dir="ltr">
+            <Head>
+                <meta charSet="utf-8"/>
+                {/* Use minimum-scale=1 to enable GPU rasterization */}
+                <meta
+                    name="viewport"
+                    content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
+                />
+                {/* PWA primary color */}
+                <meta
+                    name="theme-color"
+                    content={pageContext ? pageContext.theme.palette.primary.main : null}
+                />
+                <link
+                    rel="stylesheet"
+                    href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"
+                />
+            </Head>
+            <body>
+            <Main/>
+            <NextScript/>
+            </body>
+            </html>
+        );
+    }
+}
+
+MyDocument.getInitialProps = ctx => {
+    // Resolution order
+    //
+    // On the server:
+    // 1. app.getInitialProps
+    // 2. page.getInitialProps
+    // 3. document.getInitialProps
+    // 4. app.render
+    // 5. page.render
+    // 6. document.render
+    //
+    // On the server with error:
+    // 1. document.getInitialProps
+    // 2. app.render
+    // 3. page.render
+    // 4. document.render
+    //
+    // On the client
+    // 1. app.getInitialProps
+    // 2. page.getInitialProps
+    // 3. app.render
+    // 4. page.render
+
+    // Render app and page and get the context of the page with collected side effects.
+    let pageContext;
+    const page = ctx.renderPage(Component => {
+        const WrappedComponent = props => {
+            pageContext = props.pageContext;
+            return <Component {...props} />;
+        };
+
+        WrappedComponent.propTypes = {
+            pageContext: PropTypes.object.isRequired,
+        };
+
+        return WrappedComponent;
+    });
+
+    let css;
+    // It might be undefined, e.g. after an error.
+    if (pageContext) {
+        css = pageContext.sheetsRegistry.toString();
+    }
+
+    return {
+        ...page,
+        pageContext,
+        // Styles fragment is rendered after the app and page rendering finish.
+        styles: (
+                    <React.Fragment>
+                        <style
+                            id="jss-server-side"
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{__html: css}}
+                        />
+                        {flush() || null}
+                    </React.Fragment>
+                ),
+    };
+};
+
+export default MyDocument;

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import Button from '@material-ui/core/Button';
+import {signOut} from '../services/accounts';
+import Router from 'next/router'
+
+class Home extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    handleSubmit = async () => {
+        try {
+            await signOut();
+            Router.push('/');
+        } catch (e) {
+            console.log('Error signing out.', e);
+        }
+    }
+
+    render() {
+        return (
+            <div>
+                <div>
+                    You're logged in!
+                </div>
+                <Button color={'secondary'} variant={'outlined'} onClick={this.handleSubmit}>
+                    Sign Out
+                </Button>
+            </div>
+        )
+    }
+}
+
+export default Home;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import Button from '@material-ui/core/Button';
 import Link from 'next/link';
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,20 +1,21 @@
 import axios from 'axios';
+import Button from '@material-ui/core/Button';
+import Link from 'next/link';
 
 class Index extends React.Component {
-    state = {
-        restaurants: []
-    }
-
-    // async componentDidMount() {
-    //     const result = await axios.get('/restaurants/getAll');
-    //     console.log('result', result);
-    //     this.setState({restaurants: result.data});
-    // }
-
     render() {
         return (
             <div>
-                hello!
+                <Link href={'/signUp'}>
+                    <Button color={'primary'} variant={'outlined'}>
+                        Sign Up
+                    </Button>
+                </Link>
+                <Link href={'/signIn'}>
+                    <Button color={'secondary'} variant={'outlined'}>
+                        Sign In
+                    </Button>
+                </Link>
             </div>
         )
     }

--- a/pages/signIn.js
+++ b/pages/signIn.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import FormControl from '@material-ui/core/FormControl';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import withStyles from '@material-ui/core/styles/withStyles';
+import {signIn} from '../services/accounts';
+import Router from 'next/router';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import TextField from '@material-ui/core/TextField';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import classNames from 'classnames';
+
+const styles = theme => ({
+    main:      {
+        width:                                                    'auto',
+        display:                                                  'block', // Fix IE 11 issue.
+        marginLeft:                                               theme.spacing.unit * 3,
+        marginRight:                                              theme.spacing.unit * 3,
+        [theme.breakpoints.up(400 + theme.spacing.unit * 3 * 2)]: {
+            width:       400,
+            marginLeft:  'auto',
+            marginRight: 'auto',
+        },
+    },
+    paper:     {
+        marginTop:     theme.spacing.unit * 8,
+        display:       'flex',
+        flexDirection: 'column',
+        alignItems:    'center',
+        padding:       `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px ${theme.spacing.unit * 3}px`,
+    },
+    avatar:    {
+        margin:          theme.spacing.unit,
+        backgroundColor: theme.palette.secondary.main,
+    },
+    form:      {
+        width:     '100%', // Fix IE 11 issue.
+        marginTop: theme.spacing.unit,
+    },
+    submit:    {
+        marginTop: theme.spacing.unit * 3,
+    },
+});
+
+class SignIn extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            email:        '',
+            password:     '',
+            error:        '',
+            showPassword: false,
+        }
+    }
+
+    handleChange = prop => event => {
+        this.setState({[prop]: event.target.value});
+    };
+
+    handleSubmit = async () => {
+        try {
+            const result = await signIn(this.state.email, this.state.password);
+            console.log('result is', result);
+            Router.push(`/home`);
+        } catch (err) {
+            if (err.code === 'auth/user-not-found') {
+                this.setState({
+                                  error: `${
+                                             this.state.email
+                                             } is not registered in our system.`,
+                              });
+            } else {
+                this.setState({
+                                  error: `${err.message}`,
+                              });
+            }
+        }
+    }
+
+    handleClickShowPassword = () => {
+        this.setState(state => ({showPassword: !state.showPassword}));
+    };
+
+    render() {
+        const {classes} = this.props;
+        return (
+            <main className={classes.main}>
+                <CssBaseline/>
+                <Paper className={classes.paper}>
+                    <Avatar className={classes.avatar}>
+                        <LockOutlinedIcon/>
+                    </Avatar>
+                    <Typography component="h1" variant="h5">
+                        Sign in
+                    </Typography>
+                    <form className={classes.form}>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                label="Email"
+                                className={classNames(classes.textField)}
+                                type="email"
+                                name="email"
+                                autoComplete="email"
+                                value={this.state.email}
+                                onChange={this.handleChange('email')}
+                            />
+                        </FormControl>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                className={classNames(classes.textField)}
+                                type={this.state.showPassword ? 'text' : 'password'}
+                                label="Password"
+                                value={this.state.password}
+                                onChange={this.handleChange('password')}
+                                InputProps={{
+                                    endAdornment: (
+                                                      <InputAdornment position="end">
+                                                          <IconButton
+                                                              aria-label="Toggle password visibility"
+                                                              onClick={this.handleClickShowPassword}
+                                                          >
+                                                              {this.state.showPassword ? (
+                                                                  <VisibilityOff/>
+                                                              ) : (
+                                                                  <Visibility/>
+                                                              )}
+                                                          </IconButton>
+                                                      </InputAdornment>
+                                                  ),
+                                }}
+                            />
+                        </FormControl>
+                        <Button
+                            fullWidth
+                            variant="contained"
+                            color="primary"
+                            className={classes.submit}
+                            onClick={this.handleSubmit}>
+                            Sign In
+                        </Button>
+                    </form>
+                </Paper>
+            </main>
+        );
+    }
+}
+
+SignIn.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SignIn);

--- a/pages/signUp.js
+++ b/pages/signUp.js
@@ -174,7 +174,7 @@ class SignUp extends React.Component {
                             color="primary"
                             className={classes.submit}
                             onClick={this.handleSubmit}>
-                            Sign In
+                            Sign Up
                         </Button>
                     </form>
                 </Paper>

--- a/pages/signUp.js
+++ b/pages/signUp.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import FormControl from '@material-ui/core/FormControl';
+import RestaurantIcon from '@material-ui/icons/Restaurant';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import withStyles from '@material-ui/core/styles/withStyles';
+import {signUp, deleteUser, getCurrentUser} from '../services/accounts';
+import Router from 'next/router';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import TextField from '@material-ui/core/TextField';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import axios from 'axios';
+
+const styles = theme => ({
+    main:   {
+        width:                                                    'auto',
+        display:                                                  'block', // Fix IE 11 issue.
+        marginLeft:                                               theme.spacing.unit * 3,
+        marginRight:                                              theme.spacing.unit * 3,
+        [theme.breakpoints.up(400 + theme.spacing.unit * 3 * 2)]: {
+            width:       400,
+            marginLeft:  'auto',
+            marginRight: 'auto',
+        },
+    },
+    paper:  {
+        marginTop:     theme.spacing.unit * 8,
+        display:       'flex',
+        flexDirection: 'column',
+        alignItems:    'center',
+        padding:       `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px ${theme.spacing.unit * 3}px`,
+    },
+    avatar: {
+        margin:          theme.spacing.unit,
+        backgroundColor: theme.palette.secondary.main,
+    },
+    form:   {
+        width:     '100%', // Fix IE 11 issue.
+        marginTop: theme.spacing.unit,
+    },
+    submit: {
+        marginTop: theme.spacing.unit * 3,
+    },
+});
+
+class SignUp extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            email:        '',
+            password:     '',
+            error:        '',
+            showPassword: false,
+            firstName:    '',
+            lastName:     '',
+        }
+    }
+
+    handleChange = prop => event => {
+        this.setState({[prop]: event.target.value});
+    };
+
+    handleSubmit = async () => {
+        try {
+            const uid    = await signUp(this.state.email, this.state.password);
+            const result = await axios.post('/profile/create', {
+                firstName:    this.state.firstName,
+                lastName:     this.state.lastName,
+                userEmail:    this.state.email,
+                uid:          uid,
+                userImageURL: '#'
+            });
+
+            if (result.data.success) {
+                Router.push('/signIn');
+            } else {
+                // Delete user from Firebase auth when user was not successfully
+                // added to mysql database
+                await deleteUser((res) => console.log('User successfully deleted!'));
+                this.setState({error: 'Could not add user to the database.'});
+            }
+        } catch (err) {
+            // Delete user from Firebase auth when user was not successfully
+            // added to mysql database
+            const user = await getCurrentUser();
+            if (user) {
+                await deleteUser((res) => console.log('User successfully deleted!'));
+            }
+            this.setState({error: err.message})
+        }
+    }
+
+    handleClickShowPassword = () => {
+        this.setState(state => ({showPassword: !state.showPassword}));
+    };
+
+    render() {
+        const {classes} = this.props;
+        if (this.state.error.length > 0) {
+            console.log('Error:', this.state.error);
+        }
+        return (
+            <main className={classes.main}>
+                <CssBaseline/>
+                <Paper className={classes.paper}>
+                    <Avatar className={classes.avatar}>
+                        <RestaurantIcon/>
+                    </Avatar>
+                    <Typography component="h1" variant="h5">
+                        Sign up
+                    </Typography>
+                    <form className={classes.form}>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                label="First Name"
+                                type="text"
+                                name="firstName"
+                                value={this.state.firstName}
+                                onChange={this.handleChange('firstName')}
+                            />
+                        </FormControl>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                label="Last Name"
+                                type="text"
+                                name="lastName"
+                                value={this.state.lastName}
+                                onChange={this.handleChange('lastName')}
+                            />
+                        </FormControl>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                label="Email"
+                                type="email"
+                                name="email"
+                                autoComplete="email"
+                                value={this.state.email}
+                                onChange={this.handleChange('email')}
+                            />
+                        </FormControl>
+                        <FormControl margin="normal" required fullWidth>
+                            <TextField
+                                type={this.state.showPassword ? 'text' : 'password'}
+                                label="Password"
+                                value={this.state.password}
+                                onChange={this.handleChange('password')}
+                                InputProps={{
+                                    endAdornment: (
+                                                      <InputAdornment position="end">
+                                                          <IconButton
+                                                              aria-label="Toggle password visibility"
+                                                              onClick={this.handleClickShowPassword}
+                                                          >
+                                                              {this.state.showPassword ? (
+                                                                  <VisibilityOff/>
+                                                              ) : (
+                                                                  <Visibility/>
+                                                              )}
+                                                          </IconButton>
+                                                      </InputAdornment>
+                                                  ),
+                                }}
+                            />
+                        </FormControl>
+                        <Button
+                            fullWidth
+                            variant="contained"
+                            color="primary"
+                            className={classes.submit}
+                            onClick={this.handleSubmit}>
+                            Sign In
+                        </Button>
+                    </form>
+                </Paper>
+            </main>
+        );
+    }
+}
+
+SignUp.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SignUp);

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const handle     = app.getRequestHandler();
 const PORT       = process.env.PORT || 3000;
 const bodyParser = require('body-parser');
 const DB         = require('./app/db');
+const Profile    = require('./app/model/Profile');
 
 app.prepare()
    .then(async () => {
@@ -16,6 +17,7 @@ app.prepare()
 
            const server = express();
            server.use(bodyParser.json());
+           server.use('/profile', Profile);
 
            server.get('/showDatabases', async (req, res) => {
                try {

--- a/services/accounts.js
+++ b/services/accounts.js
@@ -1,0 +1,58 @@
+import fire from '../fire';
+
+// Function that creates an account via firebase auth
+const signUp = async (email, password) => {
+    if (!email || !password) {
+        throw `No username or password was given!`;
+    }
+
+    return fire
+        .auth()
+        .createUserWithEmailAndPassword(email, password)
+        .then(success => success.user.uid)
+        .catch(err => {
+            throw err;
+        });
+};
+
+const signIn = async (email, password) => {
+    if (!email || !password) {
+        throw `No username or password was given!`;
+    }
+
+    return fire
+        .auth()
+        .signInWithEmailAndPassword(email, password)
+        .then(success => success)
+        .catch(err => {
+            throw err;
+        });
+};
+
+const getCurrentUser = () => {
+    return new Promise((resolve) => {
+        fire.auth().onAuthStateChanged(function (user) {
+            if (user) {
+                resolve(user);
+            } else {
+                resolve(null);
+            }
+        });
+    });
+};
+
+const signOut = () => {
+    return fire.auth().signOut();
+};
+
+const deleteUser = async callback => {
+    try {
+        const user   = fire.auth().currentUser;
+        const result = await user.delete();
+        callback({success: true});
+    } catch (e) {
+        console.log('Error deleting user from firebase:', e);
+    }
+};
+
+export {signUp, signIn, signOut, getCurrentUser, deleteUser};

--- a/src/getPageContext.js
+++ b/src/getPageContext.js
@@ -1,0 +1,53 @@
+import { SheetsRegistry } from 'jss';
+import { createMuiTheme, createGenerateClassName } from '@material-ui/core/styles';
+import purple from '@material-ui/core/colors/purple';
+import green from '@material-ui/core/colors/green';
+
+// A theme with custom primary and secondary color.
+// It's optional.
+const theme = createMuiTheme({
+                                 // palette: {
+                                 //     primary: {
+                                 //         light: purple[300],
+                                 //         main: purple[500],
+                                 //         dark: purple[700],
+                                 //     },
+                                 //     secondary: {
+                                 //         light: green[300],
+                                 //         main: green[500],
+                                 //         dark: green[700],
+                                 //     },
+                                 // },
+                                 typography: {
+                                     useNextVariants: true,
+                                 },
+                             });
+
+function createPageContext() {
+    return {
+        theme,
+        // This is needed in order to deduplicate the injection of CSS in the page.
+        sheetsManager: new Map(),
+        // This is needed in order to inject the critical CSS.
+        sheetsRegistry: new SheetsRegistry(),
+        // The standard class name generator.
+        generateClassName: createGenerateClassName(),
+    };
+}
+
+let pageContext;
+
+export default function getPageContext() {
+    // Make sure to create a new context for every server-side request so that data
+    // isn't shared between connections (which would be bad).
+    if (!process.browser) {
+        return createPageContext();
+    }
+
+    // Reuse context on the client-side.
+    if (!pageContext) {
+        pageContext = createPageContext();
+    }
+
+    return pageContext;
+}


### PR DESCRIPTION
This pull request accomplish the following goals:
- Add configuration for material ui to properly server-side render
- Add firebase auth to project 
- Firebase auth methods for sign in, sign out, create account, delete account are included 
- Profile creation 
- UI for sign up and sign in 

What needs to be done in the following PR:
- Client-side error message inclusion 
- Using local storage or redux to keep track of current user and their info 
- Modify the UI to have beARguest purple theme color 
- Implement checking to see if the current user should be able to access admin pages 
- Update account information 
- UI for modifying accounts information 